### PR TITLE
Updated footer.php: Copyright-Message-Output should not be escaped

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -71,7 +71,7 @@
 						
 						<div id="copyright">
 							<?php if ( ot_get_option( 'copyright' ) ): ?>
-								<p><?php echo esc_attr( ot_get_option( 'copyright' ) ); ?></p>
+								<p><?php echo ot_get_option( 'copyright' ); ?></p>
 							<?php else: ?>
 								<p><?php bloginfo(); ?> &copy; <?php echo date( 'Y' ); ?>. <?php _e( 'All Rights Reserved.', 'hueman' ); ?></p>
 							<?php endif; ?>


### PR DESCRIPTION
There is no good reason why the copyright message output should be escaped. For example if people want to use  &lt;br/&gt; or &lt;a href=&quot;&quot;&gt;Privacy or sth like that&lt;/a&gt;