### PR TITLE
Fix: booleanize checkbox values

### DIFF
--- a/functions/init-core.php
+++ b/functions/init-core.php
@@ -67,20 +67,14 @@ function hu_booleanize_checkbox_val( $val ) {
   if ( ! $val )
     return;
 
-  switch ( $val ) {
-    case 'on':
-    case 1 :
-    case '1' :
-    case true :
-      return true;
-      break;
-
+  switch ( (string) $val ) {
     case 'off':
-    case 0 :
-    case '0' :
-    case false :
+    case '' :
       return false;
-      break;
+
+    case 'on':
+    case '1' :
+      return true;
 
     default: return false;
   }


### PR DESCRIPTION
Various issues, if the value was 'off' the switch on case 1
matched, as 'off' is a boolean true. On the other side
if the value was 1 (boolean), the case 'off' still matched, for the same reason.
Casting the value to string should fix this issue