### PR TITLE
Patch widgets construct

### DIFF
--- a/functions/widgets/alx-posts.php
+++ b/functions/widgets/alx-posts.php
@@ -15,7 +15,7 @@ class AlxPosts extends WP_Widget {
 
 /*  Constructor
 /* ------------------------------------ */
-	function AlxPosts() {
+	function __construct() {
 		parent::__construct( false, 'AlxPosts', array('description' => 'Display posts from a category', 'classname' => 'widget_hu_posts') );;
 	}
 

--- a/functions/widgets/alx-tabs.php
+++ b/functions/widgets/alx-tabs.php
@@ -15,7 +15,7 @@ class AlxTabs extends WP_Widget {
 
 /*  Constructor
 /* ------------------------------------ */
-	function AlxTabs() {
+	function __construct() {
 		parent::__construct( false, 'AlxTabs', array('description' => 'List posts, comments, and/or tags with or without tabs.', 'classname' => 'widget_hu_tabs') );;
 	}
 

--- a/functions/widgets/alx-video.php
+++ b/functions/widgets/alx-video.php
@@ -15,7 +15,7 @@ class AlxVideo extends WP_Widget {
 
 /*  Constructor
 /* ------------------------------------ */
-	function AlxVideo() {
+	function __construct() {
 		parent::__construct( false, 'AlxVideo', array('description' => 'Display a responsive video by adding a link.', 'classname' => 'widget_hu_video') );;
 	}
 


### PR DESCRIPTION
remove PHP7 notices and deprecated methods

```
Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; AlxTabs has a deprecated constructor in wp-content/themes/hueman/functions/widgets/alx-tabs.php on line 14
Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; AlxVideo has a deprecated constructor in wp-content/themes/hueman/functions/widgets/alx-video.php on line 14
Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; AlxPosts has a deprecated constructor in wp-content/themes/hueman/functions/widgets/alx-posts.php on line 14
```