### PR TITLE
Update single.php to use wp_pagenavi

### DIFF
--- a/single.php
+++ b/single.php
@@ -20,7 +20,13 @@
 					<div class="<?php echo implode( ' ', apply_filters( 'hu_single_entry_class', array('entry','themeform') ) ) ?>">
 						<div class="entry-inner">
 							<?php the_content(); ?>
-							<?php wp_link_pages(array('before'=>'<div class="post-pages">'.__('Pages:','hueman'),'after'=>'</div>')); ?>
+							<nav class="pagination group">
+							    <?php if ( function_exists('wp_pagenavi') ): ?>
+							        <?php wp_pagenavi( array( 'type' => 'multipart' ) ); ?>
+							    <?php else: ?>
+							        <?php wp_link_pages(array('before'=>'<div class="post-pages">'.__('Pages:','hueman'),'after'=>'</div>')); ?>
+							    <?php endif; ?>
+							</nav><!--/.pagination-->
 						</div>
 
             <?php do_action( 'hu_after_single_entry_inner' ); ?>


### PR DESCRIPTION
Checks for and uses wp_pagenavi to display page navigation for multi-page posts. This is consistent with 'inc/pagination.php' and provides a cleaner and more uniform page navigation visual.