### PR TITLE
The return of the Video Embed Code field

### DIFF
--- a/parts/post-formats.php
+++ b/parts/post-formats.php
@@ -145,6 +145,10 @@
         global $wp_embed;
         $video = $wp_embed->run_shortcode('[embed]'.$meta['_video_url'][0].'[/embed]');
         echo $video;
+      } elseif ( isset($meta['_video_embed_code'][0]) && !empty($meta['_video_embed_code'][0]) ) {
+				echo '<div class="video-container">';
+				echo $meta['_video_embed_code'][0];
+				echo '</div>';
       }
     ?>
   </div>


### PR DESCRIPTION
A few lines of code to support the Video Embed Code custom field entry and display had been removed going from version 2.x to 3.x. This impacts those who used the Video Embed Code field in the past when upgrading and prevents them from upgrading to latest version which is not ideal.