### PR TITLE
fix array to string error 

### DIFF
--- a/functions/init-functions.php
+++ b/functions/init-functions.php
@@ -73,6 +73,7 @@ function hu_is_partial_refreshed_on() {
 //the new options use 1 and 0
 function hu_is_checked( $opt_name = '') {
   $val = hu_get_option($opt_name);
+  $val=is_array($val)?$val[0]:$val;
   return hu_booleanize_checkbox_val( $val );
 }
 


### PR DESCRIPTION
if array is passed to hu_is_checked use first element otherwise 

'featured-posts-include' option returns an array so currently (string) $val on L83 throws error